### PR TITLE
[fix/#21] Bug: Newest entries trimmed instead of oldest

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/survivai/survivai/game/colosseum/ColosseumInfo.kt
+++ b/composeApp/src/commonMain/kotlin/com/survivai/survivai/game/colosseum/ColosseumInfo.kt
@@ -25,6 +25,9 @@ data class PlayerTitle(
 
 object ColosseumInfo {
 
+    // 상수
+    private const val COUNT_LOG_MAX = 200
+
     // 게임 초기화됨
     var initialized = false
         private set
@@ -137,9 +140,9 @@ object ColosseumInfo {
     fun addLog(message: String) {
         _logEntries.add(0, message)
         // Keep a reasonable cap
-        if (_logEntries.size > 200) {
+        if (_logEntries.size > COUNT_LOG_MAX) {
             // remove oldest extra elements to keep list bounded
-            repeat(_logEntries.size - 200) { _logEntries.removeAt(_logEntries.size - 1) }
+            repeat(_logEntries.size - COUNT_LOG_MAX) { _logEntries.removeAt(_logEntries.size - 1) }
         }
 
         // recomposition event


### PR DESCRIPTION
Linked Issue:
Close #21 

로그 역방향 제거 이슈를 해결했습니다.
추가 내용은 없습니다.

release/1.1 브랜치에서 한번에 병합 예정입니다.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes log trimming to drop oldest entries and centralizes the log cap with `COUNT_LOG_MAX = 200` in `ColosseumInfo`.
> 
> - **ColosseumInfo (`ColosseumInfo.kt`)**:
>   - **Logging**:
>     - Introduces `COUNT_LOG_MAX = 200` constant for log cap.
>     - Fixes `addLog` trimming to remove oldest entries (`removeAt(size - 1)`) while keeping newest at the front, using the constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 062399c58b6da665015faaa712fe9888003ea36f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->