### PR TITLE
[fix/#22] Bug: First Blood Race Condition in Update Loop

### DIFF
--- a/composeApp/src/webMain/kotlin/com/survivai/survivai/game/colosseum/Canvas.web.kt
+++ b/composeApp/src/webMain/kotlin/com/survivai/survivai/game/colosseum/Canvas.web.kt
@@ -114,9 +114,14 @@ class WebCanvas : Canvas {
         }
 
         // Check for winner (only once)
-        if (gameState !is GameState.Ended && alivePlayers.size == 1) {
-            log("        🏆 ${alivePlayers[0].name} 우승! 최후의 생존자!")
-            ColosseumInfo.updateGameSet()
+        if (gameState !is GameState.Ended && players.isNotEmpty()) {
+            if (alivePlayers.size == 1) {
+                log("        🏆 ${alivePlayers[0].name} 우승! 최후의 생존자!")
+                ColosseumInfo.updateGameSet()
+            } else if (alivePlayers.isEmpty()) {
+                log("        💀 전원 탈락! 살아남은 플레이어가 없습니다!")
+                ColosseumInfo.updateGameSet()
+            }
         }
 
         // Player-player overlap resolution (simple horizontal push)


### PR DESCRIPTION
Linked Issue:
Closed #22 

프레임단위로 수행하는 update() 함수 내에 존재하는 race condition 문제들을 해결했습니다.
- first blood 
- last blood

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes first-blood detection timing and ends the game when no players survive, with safety checks for non-empty player lists.
> 
> - **Game loop (`composeApp/src/webMain/kotlin/com/survivai/survivai/game/colosseum/Canvas.web.kt`)**:
>   - **First Blood**: Introduces `isFirstBloodFrame` to avoid race conditions; logs first blood once and then normal eliminations.
>   - **Game End Conditions**: Expands winner check to handle both a single survivor and the no-survivor case; guards with `players.isNotEmpty()`.
>   - **Logging/Stats**: Maintains attack/kill stat updates and adds clear logs for first blood and all-eliminated outcomes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 277cd4aaaf40859fa513b16f3086b3d860afb1de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->